### PR TITLE
feat: Add Azure product with alternatives to the products list

### DIFF
--- a/data/products.json
+++ b/data/products.json
@@ -130,7 +130,6 @@
         "country_code": "PK",
         "link": "https://frappe.io/erpnext"
       }
-      
     ]
   },
   {
@@ -208,7 +207,6 @@
       }
     ]
   },
-  
   {
     "name": "Fiverr",
     "country_code": "IL",
@@ -271,6 +269,22 @@
         "name": "Supabase",
         "country_code": "SG",
         "link": "https://supabase.com/"
+      }
+    ]
+  },
+  {
+    "name": "Azure",
+    "country_code": "US",
+    "alternatives": [
+      {
+        "name": "Google Cloud",
+        "country_code": "US",
+        "link": "https://cloud.google.com/"
+      },
+      {
+        "name": "Scaleway",
+        "country_code": "FR",
+        "link": "https://www.scaleway.com/"
       }
     ]
   }


### PR DESCRIPTION
## Description

Added Microsoft Azure to the boycott list with alternatives. Azure has been identified as a boycott target by the BDS movement due to Microsoft's contracts with the Israeli government and military. The BDS movement specifically cites Azure cloud services in their boycott calls, and there is even a dedicated campaign called "No Azure for Apartheid" targeting this product specifically.

Added two alternatives to Azure:
1. Google Cloud - A major cloud provider alternative based in the US
2. Scaleway - A European cloud provider alternative based in France

## Type of Change

- [x] Add/Edit products
- [ ] Bug fix
- [ ] New feature
- [ ] Code enhancement
- [ ] Documentation update

## Checklist

- [x] I have tested my changes locally
- [x] My code follows the project's coding style